### PR TITLE
Printing modification for OS X Terminal

### DIFF
--- a/igeek.zsh-theme
+++ b/igeek.zsh-theme
@@ -1,13 +1,13 @@
 # igeek zsh-theme
 
 # System load
-g_load=`top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{printf "☉ System load : %.1f%", 100-$1 }'`
+g_load=`top -n1 | head | grep "CPU usage" | sed "s/.*, *\([0-9.]*\)%* idle.*/\1/" | awk '{printf "☉ CPU Usage : %.1f%%", 100-$1 }'`
 
 # Memory Usage
-g_memory=`free -m | awk 'NR==2{printf "☉ Memory Usage: %.2f%", $3*100/$2 }'`
+g_memory=`memory_pressure | grep "System-wide memory" | awk '{printf "☉ Memory Usage: %.2f%%", $5 }'`
 
 # Disk Usage
-g_disk=`df -h | awk '$NF=="/"{printf "☉ Disk Usage: %.1f%", $5}'`
+g_disk=`df -h | awk '$NF=="/"{printf "☉ Disk Usage: %.1f%%", $5}'`
 
 # System uptime
 g_uptime=`uptime | awk -F'( |,|:)+' '{ if ($7=="min") m=$6; else { if ($7~/^day/) { d=$6; h=$8; m=$9} else {h=$6;m=$7}}}{print "☉ System uptime:",d+0,"days,",h+0,"hours"}'`


### PR DESCRIPTION
Resolving issues with `top` and `free` commands on OS X:

```
invalid option or syntax: -bn1
top usage: top
...
command not found: free
...
awk: weird printf conversion %
 input record number 2, file 
 source line number 1
awk: not enough args in printf(☉ Disk Usage: %.1f%)
 input record number 2, file 
 source line number 1

```