### PR TITLE
Updated the file to fix the awk errors

### DIFF
--- a/igeek.zsh-theme
+++ b/igeek.zsh-theme
@@ -1,16 +1,16 @@
 # igeek zsh-theme
 
 # System load
-g_load=`top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{printf "☉ System load : %.1f%", 100-$1 }'`
+g_load=$(top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{printf "☉ System load : %.1f%%", 100-$1 }')
 
 # Memory Usage
-g_memory=`free -m | awk 'NR==2{printf "☉ Memory Usage: %.2f%", $3*100/$2 }'`
+g_memory=$(free -m | awk 'NR==2{printf "☉ Memory Usage: %.2f%", $3*100/$2 }')
 
 # Disk Usage
-g_disk=`df -h | awk '$NF=="/"{printf "☉ Disk Usage: %.1f%", $5}'`
+g_disk=$(df -h | awk '$NF=="/"{printf "☉ Disk Usage: %.1f%", $5}')
 
 # System uptime
-g_uptime=`uptime | awk -F'( |,|:)+' '{ if ($7=="min") m=$6; else { if ($7~/^day/) { d=$6; h=$8; m=$9} else {h=$6;m=$7}}}{print "☉ System uptime:",d+0,"days,",h+0,"hours"}'`
+g_uptime=$(uptime | awk -F'( |,|:)+' '{ if ($7=="min") m=$6; else { if ($7~/^day/) { d=$6; h=$8; m=$9} else {h=$6;m=$7}}}{print "☉ System uptime:",d+0,"days,",h+0,"hours"}')
 
 # array System information
 g_listOfNames=("$g_load" "$g_memory" "$g_disk" "$g_uptime")


### PR DESCRIPTION
I have added a second `%` for the percentage sign to appear on the screen, I have also changed the format from encapsulating your commands with `$()` After that, the `awk` and `gawk` error messages have disappeared.